### PR TITLE
query: add multiple query wrapper functions

### DIFF
--- a/query.go
+++ b/query.go
@@ -164,3 +164,10 @@ func EventualConsistency() Query {
 		return q.EventualConsistency()
 	}
 }
+
+// Distinct adds distinct to query
+func Distinct() Query {
+	return func(q *datastore.Query) *datastore.Query {
+		return q.Distinct()
+	}
+}

--- a/query.go
+++ b/query.go
@@ -150,3 +150,10 @@ func Transaction(t *datastore.Transaction) Query {
 		return q.Transaction(t)
 	}
 }
+
+// Ancestor adds ancestor to query
+func Ancestor(ancestor *datastore.Key) Query {
+	return func(q *datastore.Query) *datastore.Query {
+		return q.Ancestor(ancestor)
+	}
+}

--- a/query.go
+++ b/query.go
@@ -171,3 +171,10 @@ func Distinct() Query {
 		return q.Distinct()
 	}
 }
+
+// DistinctOn adds distinct on to query
+func DistinctOn(fieldNames ...string) Query {
+	return func(q *datastore.Query) *datastore.Query {
+		return q.DistinctOn(fieldNames...)
+	}
+}

--- a/query.go
+++ b/query.go
@@ -157,3 +157,10 @@ func Ancestor(ancestor *datastore.Key) Query {
 		return q.Ancestor(ancestor)
 	}
 }
+
+// EventualConsistency adds eventual consistency to query
+func EventualConsistency() Query {
+	return func(q *datastore.Query) *datastore.Query {
+		return q.EventualConsistency()
+	}
+}


### PR DESCRIPTION
- Ancestor
- EventualConsistency
- Distinct
- DistinctOn